### PR TITLE
shrink image size, fix non-root permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN pip3 install Pygments
 RUN apt-get install -y inkscape
 # latexrun
 ADD https://raw.githubusercontent.com/aclements/latexrun/master/latexrun /latexrun.py
+RUN chmod 644 /latexrun.py
 # working directory
-RUN mkdir /latex
 WORKDIR /latex
 # environment variables
 ENV WARNINGS -Wall

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,19 @@ FROM ubuntu:20.04
 RUN apt-get update &&\
     DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true \
-    apt-get install -y --no-install-recommends apt-utils \
-    tzdata \
-    texlive-latex-base \
-    texlive-fonts-recommended \
-    texlive-latex-extra \
-    texlive-lang-german \
+    apt-get install -y --no-install-recommends \
+    apt-utils \
     biber \
-    texlive-bibtex-extra \
+    inkscape \
     python3 \
     python3-pip \
-    inkscape
-
+    texlive-bibtex-extra \
+    texlive-fonts-recommended \
+    texlive-lang-german \
+    texlive-latex-base \
+    texlive-latex-extra \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/*
 # pygments for syntax highlighting via minted
 RUN pip3 install Pygments
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,35 @@
 FROM ubuntu:20.04
 
-RUN apt-get update
-# fix for delayed debconf
-RUN apt-get install -y --no-install-recommends apt-utils
-# fix for tzdata package:
-ARG DEBIAN_FRONTEND=noninteractive
-ARG DEBCONF_NONINTERACTIVE_SEEN=true
-RUN apt-get install tzdata
-# texlive stuff and things
-RUN apt-get install -y texlive-latex-base
-RUN apt-get install -y texlive-fonts-recommended
-#RUN apt-get install -y texlive-fonts-extra
-RUN apt-get install -y texlive-latex-extra
-# support for babel ngerman
-RUN apt-get install -y texlive-lang-german
-# bibtex
-RUN apt-get install -y biber
-RUN apt-get install -y texlive-bibtex-extra
-# pygmentize
-RUN apt-get install -y python3
-RUN apt-get install -y python3-pip
+# debian packages: tzdata, texlive, python, inkscape
+RUN apt-get update &&\
+    DEBIAN_FRONTEND=noninteractive \
+    DEBCONF_NONINTERACTIVE_SEEN=true \
+    apt-get install -y --no-install-recommends apt-utils \
+    tzdata \
+    texlive-latex-base \
+    texlive-fonts-recommended \
+    texlive-latex-extra \
+    texlive-lang-german \
+    biber \
+    texlive-bibtex-extra \
+    python3 \
+    python3-pip \
+    inkscape
+
+# pygments for syntax highlighting via minted
 RUN pip3 install Pygments
-# inkscape
-RUN apt-get install -y inkscape
-# latexrun
+
 ADD https://raw.githubusercontent.com/aclements/latexrun/master/latexrun /latexrun.py
+# allow non-root container run
 RUN chmod 644 /latexrun.py
-# working directory
 WORKDIR /latex
-# environment variables
+
+# settings (used in compile.sh)
 ENV WARNINGS -Wall
 ENV DELETE_TEMP=
 ENV CLEAN_BUILD=
 ENV TARGET main
 
-# compilation script
 COPY compile.sh /
 
 CMD ["bash", "/compile.sh"]


### PR DESCRIPTION
this PR greatly reduces the size of the image by condensing all of the `apt install` layers into one.
* compressed: 448mb -> 234mb
* uncompressed (local): 1.47gb -> 754mb
switching from ubuntu to alpine in the future may lead to even smaller image sizes

also, the /latexrun.py file had 600 permisions which prevented the container from running as non-root