### PR TITLE
mini pythontex fix (log output)

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,12 +1,13 @@
+#!/bin/bash
 BUILDDIR_FULL=$BIND_PATH/$BUILD_DIRECTORY
-if [ ! "$CLEAN_BUILD" == "" ] && [ -d "$BUILDDIR_FULL" ]; then
+if [ ! "$CLEAN_BUILD" = "" ] && [ -d "$BUILDDIR_FULL" ]; then
   rm -r "$BUILDDIR_FULL"
 fi
 mkdir -p "$BUILDDIR_FULL"
 cp -r -u "$BIND_PATH"/* "$BUILDDIR_FULL/"
 cd "$BUILDDIR_FULL"
 # this variable is empty by default -> fill to disable
-if [ "$DISABLE_PYTHONTEX" == "" ]; then
+if [ "$DISABLE_PYTHONTEX" = "" ]; then
   # we could use a bare pdflatex here
   # however, latexrun itself is smart enough to only run pdflatex once
   # don't print the output since latexrun will be re-run anyway
@@ -23,6 +24,6 @@ fi
 # this is a && chain - new files won't be copied if the build fails
 python3 /latexrun.py --latex-args=--shell-escape --bibtex-cmd biber -O . $WARNINGS $TARGET && \
 cp -u "$BUILDDIR_FULL/main.pdf" "$BIND_PATH/main.pdf" && \
-if [ ! "$DELETE_TEMP" == "" ]; then
+if [ ! "$DELETE_TEMP" = "" ]; then
   rm -r "$BUILDDIR_FULL"
 fi

--- a/compile.sh
+++ b/compile.sh
@@ -11,7 +11,14 @@ if [ "$DISABLE_PYTHONTEX" == "" ]; then
   # however, latexrun itself is smart enough to only run pdflatex once
   # don't print the output since latexrun will be re-run anyway
   python3 /latexrun.py --latex-args=--shell-escape --bibtex-cmd biber -O . $WARNINGS $TARGET > /dev/null
-  pythontex --interpreter python:python3 main
+  if [ -f "$BUILDDIR_FULL/$TARGET.pytxcode" ]; then
+    # only run pythontex if a pytxcode file was generated
+    # this prevents the useless invocation of pythontex when the package wasn't used at all
+    if ! pythontex --interpreter python:python3 $TARGET &> "$BUILDDIR_FULL/$TARGET.pythontex.log"; then
+      # ony forward the pythontex log output if errors occured - we don't care otherwise
+      cat "$BUILDDIR_FULL/$TARGET.pythontex.log"
+    fi
+  fi
 fi
 # this is a && chain - new files won't be copied if the build fails
 python3 /latexrun.py --latex-args=--shell-escape --bibtex-cmd biber -O . $WARNINGS $TARGET && \


### PR DESCRIPTION
this disables log output for pythontex in case pythontex isn't used.
we also no longer print the pythontex output if the execution was successful as it clutters the terminal too much

this pr also includes a minor syntactical change which will have no effect on functionality

fixes #7 