### PR TITLE
push latest together with vx.y.z instead of own build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,10 +23,9 @@ jobs:
             jemand771/latex-build
             ghcr.io/jemand771/latex-build
           flavor: |
-            latest=false
+            latest=true
           tags: |
             type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{version}},value=latest
             type=raw,enable=${{ github.ref == 'refs/heads/dev' }},value=experimental
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,6 @@ name: docker-build
 on:
   push:
     branches:
-      - "main"
       - "dev"
     tags:
       - "v*.*.*"
@@ -27,7 +26,7 @@ jobs:
             latest=false
           tags: |
             type=semver,pattern=v{{version}}
-            type=raw,enable=${{ github.ref == 'refs/heads/main' }},value=latest
+            type=semver,pattern=v{{version}},value=latest
             type=raw,enable=${{ github.ref == 'refs/heads/dev' }},value=experimental
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,7 +20,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ghcr.io/jemand771/latex-build
+          images: |
+            jemand771/latex-build
+            ghcr.io/jemand771/latex-build
           flavor: |
             latest=false
           tags: |


### PR DESCRIPTION
this disallows rebuilding older tags on gh actions since that would overwrite `latest`. since I won't do that, this just adds consistency