### PR TITLE
release --no-install-recommends in diff-pdf stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ WORKDIR /tmp
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
     automake \
     autotools-dev \
     build-essential \
+    ca-certificates \
     git \
     libwxgtk3.0-gtk3-dev \
     libpoppler-glib-dev \


### PR DESCRIPTION
while this doesn't affect the final image size, it should speed up the overall build time