### PR TITLE
pin python version to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update &&\
     biber \
     inkscape \
     libwxgtk3.0-gtk3-dev \
-    python3 \
+    python-is-python3 \
+    python3.10 \
     python3-pip \
     texlive-bibtex-extra \
     texlive-extra-utils \
@@ -48,15 +49,14 @@ RUN apt-get update &&\
 && \
     rm -rf /var/lib/apt/lists/*
 
+# NOTE on python-is-python3 minted expects "python" in PATH (not "python3")
+# without this, things like autogobble with \inputminted break
+# https://github.com/alexpovel/latex-extras-docker/blob/5429a82ef415c2e9eda0c20f71e7df63b51621e9/Dockerfile#L80-L87
+
 # install custom pygments lexers
 WORKDIR /usr/local/lib/python3.10/dist-packages/pygments/lexers
 COPY pygments-lexers/* .
 RUN python3 _mapping.py
-
-# minted expects "python" in PATH (not "python3")
-# without this, things like autogobble with \inputminted break
-# https://github.com/alexpovel/latex-extras-docker/blob/5429a82ef415c2e9eda0c20f71e7df63b51621e9/Dockerfile#L80-L87
-RUN ln -s /usr/bin/python3 /usr/bin/python
 
 ADD https://raw.githubusercontent.com/aclements/latexrun/master/latexrun /latexrun.py
 # allow non-root container run


### PR DESCRIPTION
this prevents breakage once newer python versions are available in ubuntu's apt repo

fixes #34 